### PR TITLE
ユーザ管理機能③実装

### DIFF
--- a/app/assets/stylesheets/operations.scss
+++ b/app/assets/stylesheets/operations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the operations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/tweets.scss
+++ b/app/assets/stylesheets/tweets.scss
@@ -134,6 +134,14 @@ ul{
   text-align: center;
 }
 
+.admin-content{
+  margin-bottom: 10px;
+}
+
+.admin-content-top{
+  background-color: cyan;
+  text-align: center;
+}
 
 
 .main{

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -12,7 +12,7 @@
   background-size: cover;
   background-color:rgba(255,255,255,0.4);
   background-blend-mode:lighten;
-  height:200vh;
+  height:220vh;
 }
 
 .contents_edit{
@@ -21,7 +21,7 @@
   background-size: cover;
   background-color:rgba(255,255,255,0.4);
   background-blend-mode:lighten;
-  height:300vh;
+  height:280vh;
 }
 
 .contents_edit_stu{
@@ -112,6 +112,16 @@
   width:50vw;
 }
 
+.title-ope{
+  color:cyan;
+  font-family:"Helvetica Neue",Arial,"Hiragino Kaku Gothic ProN","Hiragino Sans",Meiryo,sans-serif;
+  font-size:30px;
+  font-weight:900;
+  background-color:rgba(255,0,0,0.5);
+  padding-left:20px;
+  margin-bottom:10px;
+}
+
 *{
   text-decoration: none;
 }
@@ -165,4 +175,15 @@ body {
 
 .top{
   display: flex;
+}
+
+.content-post-area-ope{
+  width: 80vw;
+  height: 45vh;
+  margin-top: 10px;
+  background-color: #fad9e9;
+}
+
+.auth{
+  margin:30px;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
 
   private
   def configure_permitted_parameters
-    added_attrs = [:email,:LastName,:FirstName,:birthday,:aWord,:favoriteSubject,:Nickname,:student_or_cauch,:university,:department,:major,:status_identification, :user_icon, :password, :password_confirmation, :remember_me, :user_identification]
+    added_attrs = [:email,:LastName,:FirstName,:birthday,:aWord,:favoriteSubject,:Nickname,:student_or_coach,:university,:department,:major,:admin, :user_icon, :password, :password_confirmation, :remember_me, :user_identification]
     devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
     devise_parameter_sanitizer.permit :account_update, keys: added_attrs
   end

--- a/app/controllers/operations_controller.rb
+++ b/app/controllers/operations_controller.rb
@@ -1,0 +1,11 @@
+class OperationsController < ApplicationController
+  def index
+    @users = User.all
+  end
+
+  def edit
+    puts params[:id]
+    redirect_to root_path
+  end
+
+end

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -1,6 +1,7 @@
 class TweetsController < ApplicationController
   def index
     @tweets = Tweet.all
+    @tweet = Tweet.new
   end
 
   def new

--- a/app/helpers/operations_helper.rb
+++ b/app/helpers/operations_helper.rb
@@ -1,0 +1,2 @@
+module OperationsHelper
+end

--- a/app/models/operation.rb
+++ b/app/models/operation.rb
@@ -1,0 +1,3 @@
+class Operation < ApplicationRecord
+
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.student_or_cauch == "cauch" %>
+<% if current_user.student_or_coach == "coach" %>
 <div class="contents_edit">
 <% else %>
 <div class="contents_edit_stu">
@@ -56,7 +56,7 @@
            <%= f.file_field :user_icon %>
        </div>
 
-       <% if current_user.student_or_cauch ==  "cauch" %>
+       <% if current_user.student_or_coach ==  "coach" %>
         <div class="field">
           <%= f.label :"大学名" %><br />
           <%= f.text_field :university, autofocus: true %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -53,14 +53,18 @@
           <%= f.text_field :major, autofocus: true %>
        </div>
         <div class="field">
+          <%= f.label :"ユーザアイコン (ご自身の顔が写った写真をアイコンに設定)" %>
+          <%= f.file_field :user_icon %>
+        </div>
+        <div class="field">
          <p class="warn">【本人認証】ご自身の顔と学生証が一緒に写った画像をアップロード</p>
            <%= f.file_field :user_identification %>
         </div>
         <div class="field">
-           <%= f.hidden_field :status_identification ,value: "Unapproved" %>
+           <%= f.hidden_field :admin ,value: "false" %>
         </div>
           <div class="field">
-           <%= f.hidden_field :student_or_cauch ,value: "student" %>
+           <%= f.hidden_field :student_or_coach ,value: "student" %>
         </div>
         <div class="field">
           <%= f.submit "登録する", class: "btn-n btn--orange btn--shadow" %>

--- a/app/views/operations/index.html.erb
+++ b/app/views/operations/index.html.erb
@@ -1,0 +1,47 @@
+<%= render partial: "tweets/header" %>
+<div class="middle-content">
+  <%= render partial: "tweets/sidebar" %>
+  <div class="main">
+    <p class="title-ope">講師希望ユーザ一覧</p>
+   <% @users.each do |user| %>
+     <% if user.user_identification.attached? && user.student_or_coach == "student"  %>
+     <div class="content-post-area-ope">
+    <div class="content-post-right">
+      <div class="content-post-right-top">
+        <p class="contributor-name"><%= user.Nickname %></p>
+         <%= link_to image_tag(user.user_icon, class: 'icon' )  , root_path  %>
+      </div>
+    </div>
+    <div class="content-post-right">
+      <div class="content-post-right-top">
+        <p class="contributor-name"><%= "本名：" + user.FirstName + user.LastName %></p>
+      </div>
+    </div>
+    <div class="content-post-right">
+      <div class="content-post-right-top">
+        <p class="contributor-name"><%= "大学：" + user.university %></p>
+      </div>
+    </div>
+    <div class="content-post-right">
+      <div class="content-post-right-top">
+        <p class="contributor-name"><%= "学部学科：" + user.department + "学部" + user.major + "学科" %></p>
+      </div>
+    </div>
+    <div class="content-post-bottom">
+       <div>
+          <p class="contributor-name">本人証明画像</p>
+       </div>
+       <div>
+          <%= link_to image_tag(user.user_identification)  , root_path  %>
+       </div>
+       <div class="auth">
+        <%= link_to "講師として承認する"  , edit_operation_path(user.id) ,class: "btn btn--blue btn--shadow" %>
+       </div>
+    </div>
+    </div>
+   <% end %>     
+   <% end %>
+  </div>
+  
+</div>
+<%= render partial: "tweets/footer" %>

--- a/app/views/tweets/_sidebar.html.erb
+++ b/app/views/tweets/_sidebar.html.erb
@@ -19,7 +19,9 @@
               <li><a class="side-bar-content"  href="/">My研究</a></li>
             </ul>
         </div>
+        <% if user_signed_in? %>
         <div class="coach-content">
+            <% if current_user.student_or_coach == "student" %>
           <div class="coach-content-for-student">
             <div class="coach-content-top">
               <b class="top-item">コーチ</b>
@@ -30,6 +32,7 @@
                 <li><a class="side-bar-content"  href="/">コーチになる</a></li>
               </ul>
           </div>
+            <% elsif current_user.student_or_coach == "coach"   %>
           <div class="coach-content-for-coach">
             <div class="coach-content-top">
               <b class="top-item">コーチ</b>
@@ -40,5 +43,19 @@
                 <li><a class="side-bar-content"  href="/">コーチランキング</a></li>
               </ul>
           </div>
+            <% end %>
         </div> 
+            <% if current_user.admin == "true" %>
+        <div class="admin-content">
+          <div class="admin-content-top">
+            <b class="top-item">運営</b>
+          </div>
+            <ul>
+              <li> <%= link_to "講師承認", operations_path , class: "side-bar-content" %></li>
+              <li><a class="side-bar-content"  href="/">-</a></li>
+              <li><a class="side-bar-content"  href="/">-</a></li>
+            </ul>
+        </div>
+            <% end %>
+        <% end %>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
 
   root to: 'tweets#index'
   resources :tweets, only: [:index, :new, :create]
+  resources :operations , only: [:index,:edit]
 end

--- a/db/migrate/20210704034045_rename_status_identification_column_to_users.rb
+++ b/db/migrate/20210704034045_rename_status_identification_column_to_users.rb
@@ -1,0 +1,5 @@
+class RenameStatusIdentificationColumnToUsers < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :users, :status_identification, :admin
+  end
+end

--- a/db/migrate/20210704035954_rename_student_or_cauch_column_to_users.rb
+++ b/db/migrate/20210704035954_rename_student_or_cauch_column_to_users.rb
@@ -1,0 +1,5 @@
+class RenameStudentOrCauchColumnToUsers < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :users, :student_or_cauch, :student_or_coach
+  end
+end

--- a/db/migrate/20210704045904_create_operations.rb
+++ b/db/migrate/20210704045904_create_operations.rb
@@ -1,0 +1,8 @@
+class CreateOperations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :operations do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_27_031235) do
+ActiveRecord::Schema.define(version: 2021_07_04_045904) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -33,6 +33,11 @@ ActiveRecord::Schema.define(version: 2021_06_27_031235) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
+  create_table "operations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "tweets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "tweet"
     t.integer "user_id"
@@ -52,8 +57,8 @@ ActiveRecord::Schema.define(version: 2021_06_27_031235) do
     t.string "university", default: "", null: false
     t.string "department", default: "", null: false
     t.string "major", default: "", null: false
-    t.string "status_identification", default: "", null: false
-    t.string "student_or_cauch", default: "", null: false
+    t.string "admin", default: "", null: false
+    t.string "student_or_coach", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"

--- a/test/controllers/operations_controller_test.rb
+++ b/test/controllers/operations_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class OperationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/operations.yml
+++ b/test/fixtures/operations.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/operation_test.rb
+++ b/test/models/operation_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class OperationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
■ 実装内容
1. Userテーブルの「status_identification」カラムを「admin」カラムに変更
2. ユーザのステータス(生徒・講師・管理者)によって、サイドバーの表示が変わるように実装
3. サイドバーに管理者のみが利用可能な「運営」を表示し、「運営機能」に関わるテーブルおよびモデル「operation」、
　 コントローラ「operations」、ルーティングを作成
4. 管理者はサイドバーの「運営」→「講師承認」から、講師を希望するユーザの一覧に遷移することが可能
　※上記の一覧から管理者がユーザに講師ステータスを付与する実装は以降のブランチにて実施予定

■ 連絡事項
 講師の本人認証関連について、特記事項を整理しておきます。 

1.  講師希望者の本人証明ステータスのカラム「status_identification」は活用できる場面が少なく、不要なため廃止
2.  講師希望のユーザはサインアップ画面にて、大学名や本人証明画像等を入力して新規登録されるが、登録時はデフォルトで
　「student_or_coach」カラムを「student」にセットし、生徒ステータスとする。
3.  管理者はサイドバーの「講師承認」から、講師を希望するユーザ(ユーザ登録時に大学名や本人認証画像を入力したユーザ)の
　 一覧を参照することが可能。
　※各々のユーザに対し、講師ステータスを付与(「student_or_coach」カラムを「student」から「coach」に変更)する処理は
　  未実装 (コントローラの作成など、基本的な枠組みまで作成済)
4.  上記3.の処理が可能な「管理者」ユーザをWeb上で作成したり、ステータスを付与したりする機能は実装しない。
　 (セキュリティ考慮)「管理者」ステータスを持つユーザは運営にて事前にDB内に作成準備しておく。