### PR TITLE
オペレーションDBの削除

### DIFF
--- a/db/migrate/20210718110919_operations.rb
+++ b/db/migrate/20210718110919_operations.rb
@@ -1,5 +1,0 @@
-class Operations < ActiveRecord::Migration[6.0]
-  def change
-    drop_table :operations
-  end
-end


### PR DESCRIPTION
不要な、オペレーションDBの削除
 円滑なデプロイのため